### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CreditCardView.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CreditCardView.java
@@ -23,23 +23,6 @@ import io.codetail.animation.ViewAnimationUtils;
  */
 public class CreditCardView extends FrameLayout {
 
-
-    public String getCardHolderName() {
-        return mCardHolderName;
-    }
-
-    public String getCVV() {
-        return mCVV;
-    }
-
-    public String getExpiry() {
-        return mExpiry;
-    }
-
-    interface ICustomCardSelector {
-        CardSelector getCardSelector(String cardNumber);
-    }
-
     private static final int TEXTVIEW_CARD_HOLDER_ID = R.id.front_card_holder_name;
     private static final int TEXTVIEW_CARD_EXPIRY_ID = R.id.front_card_expiry;
     private static final int TEXTVIEW_CARD_NUMBER_ID = R.id.front_card_number;
@@ -56,7 +39,6 @@ public class CreditCardView extends FrameLayout {
 
     private String mCardHolderName, mCVV, mExpiry;
 
-
     public CreditCardView(Context context) {
         super(context);
         init();
@@ -72,6 +54,22 @@ public class CreditCardView extends FrameLayout {
         init(attrs);
     }
 
+    public String getCardHolderName() {
+        return mCardHolderName;
+    }
+
+    public String getCVV() {
+        return mCVV;
+    }
+
+    public String getExpiry() {
+        return mExpiry;
+    }
+
+    interface ICustomCardSelector {
+        CardSelector getCardSelector(String cardNumber);
+    }
+    
     private void init() {
 
         mCurrentDrawable = R.drawable.card_color_round_rect_default;

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/FlipAnimator.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/FlipAnimator.java
@@ -25,30 +25,15 @@ public class FlipAnimator extends Animation {
     private boolean visibilitySwapped;
 
     private int rotationDirection = DIRECTION_X;
-    public int getRotationDirection() {
-		return rotationDirection;
-	}
 
-	public void setRotationDirection(int rotationDirection) {
-		this.rotationDirection = rotationDirection;
-	}
+    private int translateDirection = DIRECTION_Z;
 
-	public int getTranslateDirection() {
-		return translateDirection;
-	}
-
-	public void setTranslateDirection(int translateDirection) {
-		this.translateDirection = translateDirection;
-	}
-
-	private int translateDirection = DIRECTION_Z;
-    
     /**
      * Creates a 3D flip animation between two views. If forward is true, its
      * assumed that view1 is "visible" and view2 is "gone" before the animation
      * starts. At the end of the animation, view1 will be "gone" and view2 will
      * be "visible". If forward is false, the reverse is assumed.
-     * 
+     *
      * @param fromView First view in the transition.
      * @param toView Second view in the transition.
      * @param centerX The center of the views in the x-axis.
@@ -64,6 +49,22 @@ public class FlipAnimator extends Animation {
         setFillAfter(true);
         setInterpolator(new AccelerateDecelerateInterpolator());
     }
+
+    public int getRotationDirection() {
+		return rotationDirection;
+	}
+
+	public void setRotationDirection(int rotationDirection) {
+		this.rotationDirection = rotationDirection;
+	}
+
+	public int getTranslateDirection() {
+		return translateDirection;
+	}
+
+	public void setTranslateDirection(int translateDirection) {
+		this.translateDirection = translateDirection;
+	}
 
     public void reverse() {
         forward = false;

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardFragmentAdapter.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardFragmentAdapter.java
@@ -27,11 +27,6 @@ public class CardFragmentAdapter extends FragmentStatePagerAdapter implements IA
 
     private ICardEntryCompleteListener mCardEntryCompleteListener;
 
-    public void setOnCardEntryCompleteListener(ICardEntryCompleteListener listener) {
-        this.mCardEntryCompleteListener = listener;
-    }
-
-
     public CardFragmentAdapter(FragmentManager fm, Bundle args) {
         super(fm);
 
@@ -52,6 +47,10 @@ public class CardFragmentAdapter extends FragmentStatePagerAdapter implements IA
         mCardExpiryFragment.setActionListener(this);
         mCardCVVFragment.setActionListener(this);
 
+    }
+
+    public void setOnCardEntryCompleteListener(ICardEntryCompleteListener listener) {
+        this.mCardEntryCompleteListener = listener;
     }
 
     @Override

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardNumberFragment.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardNumberFragment.java
@@ -19,10 +19,11 @@ import static com.cooltechworks.creditcarddesign.CreditCardUtils.MAX_LENGTH_CARD
  */
 public class CardNumberFragment extends  CreditCardFragment {
 
+    EditText mCardNumberView;
+
     public CardNumberFragment() {
 
     }
-    EditText mCardNumberView;
 
     public View onCreateView(LayoutInflater inflater, ViewGroup group, Bundle state) {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat