### PR TITLE
squid:UselessParenthesesCheck, squid:S1197- Useless parentheses aroun…

### DIFF
--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CardSelector.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CardSelector.java
@@ -93,7 +93,7 @@ public class CardSelector {
 
             if(selector != DEFAULT) {
 
-                int drawables[] = { R.drawable.card_color_round_rect_brown, R.drawable.card_color_round_rect_green, R.drawable.card_color_round_rect_pink, R.drawable.card_color_round_rect_purple, R.drawable.card_color_round_rect_blue};
+                int[] drawables = { R.drawable.card_color_round_rect_brown, R.drawable.card_color_round_rect_green, R.drawable.card_color_round_rect_pink, R.drawable.card_color_round_rect_purple, R.drawable.card_color_round_rect_blue};
                 int hash = cardNumber.substring(0,3).hashCode();
 
                 if(hash<0) {
@@ -103,8 +103,8 @@ public class CardSelector {
                 int index = hash % drawables.length;
 
                 int chipIndex = hash % 3;
-                int chipOuter[] = { R.drawable.chip, R.drawable.chip_yellow, android.R.color.transparent};
-                int chipInner[] = { R.drawable.chip_inner, R.drawable.chip_yellow_inner,android.R.color.transparent};
+                int[] chipOuter = { R.drawable.chip, R.drawable.chip_yellow, android.R.color.transparent};
+                int[] chipInner = { R.drawable.chip_inner, R.drawable.chip_yellow_inner,android.R.color.transparent};
 
 
                 selector.setResCardId(drawables[index]);

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CreditCardView.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CreditCardView.java
@@ -307,8 +307,8 @@ public class CreditCardView extends FrameLayout {
         }
 
         int duration = 1000;
-        int cx = (mRevealView.getLeft());
-        int cy = (mRevealView.getTop());
+        int cx = mRevealView.getLeft();
+        int cy = mRevealView.getTop();
 
         int radius = Math.max(mRevealView.getWidth(), mRevealView.getHeight()) * 4;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat